### PR TITLE
Feature/jungle book bug fix

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -14,7 +14,7 @@ var googleKey = "AIzaSyCgSuPSLRf6S38F_qQ6Yssx2NdKM2mdtS0";
         url:googleUrl,
         method:"GET"
         }).then(function(bookGet){
-        // console.log(bookGet); 
+        console.log(bookGet); 
         
         for (i=0; i<9; i++){
         
@@ -22,8 +22,9 @@ var googleKey = "AIzaSyCgSuPSLRf6S38F_qQ6Yssx2NdKM2mdtS0";
         var subtitle = bookGet.items[i].volumeInfo.subtitle;
         var authors = bookGet.items[i].volumeInfo.authors[0]; //in case of multiple authors this won't work
         var coverSm = bookGet.items[i].volumeInfo.imageLinks.smallThumbnail; //img link
-        var synop = bookGet.items[i].searchInfo.textSnippet;
-        var buyLink = bookGet.items[0].saleInfo.buyLink;
+        // var synop = bookGet.items[i].searchInfo.textSnippet;
+        var buyLink = bookGet.items[i].saleInfo.buyLink;
+        var selfLink = bookGet.items[i].selfLink;
          
         var resultsCard = $("<div>");
         var coverImg = $("<img>");
@@ -35,8 +36,9 @@ var googleKey = "AIzaSyCgSuPSLRf6S38F_qQ6Yssx2NdKM2mdtS0";
         cardTitle.text(title);
         cardSubtitle.text(subtitle);
         cardAuthor.text(authors);
-        cardSynop.html(synop);
-        cardBuy.text("Link to purchase: "+buyLink);
+        // cardSynop.html(synop);
+        // cardBuy.text("Link to purchase: "+buyLink);
+        cardBuy.text("Link to google books: "+selfLink);
         coverImg.attr("src", coverSm);
         resultsCard.attr("class", "card");
         resultsCard.append(cardTitle);

--- a/assets/script.js
+++ b/assets/script.js
@@ -20,12 +20,16 @@ var googleKey = "AIzaSyCgSuPSLRf6S38F_qQ6Yssx2NdKM2mdtS0";
         
         var title = bookGet.items[i].volumeInfo.title;
         var subtitle = bookGet.items[i].volumeInfo.subtitle;
-        var authors = bookGet.items[i].volumeInfo.authors[0]; //in case of multiple authors this won't work
-        var coverSm = bookGet.items[i].volumeInfo.imageLinks.smallThumbnail; //img link
-        // var synop = bookGet.items[i].searchInfo.textSnippet;
-        var buyLink = bookGet.items[i].saleInfo.buyLink;
+        var coverLg = bookGet.items[i].volumeInfo.imageLinks.thumbnail; //img link
+        // var buyLink = bookGet.items[i].saleInfo.buyLink;
         var selfLink = bookGet.items[i].selfLink;
-         
+        
+        var authors = bookGet.items[i].volumeInfo.authors[0]; //in case of multiple authors this won't work
+        // var synop = bookGet.items[i].searchInfo.textSnippet;
+
+        if (bookGet.items[i].searchInfo) {var synop = bookGet.items[i].searchInfo.textSnippet;}else{var synop ="Error"}
+
+
         var resultsCard = $("<div>");
         var coverImg = $("<img>");
         var cardTitle = $("<h4>");
@@ -36,12 +40,9 @@ var googleKey = "AIzaSyCgSuPSLRf6S38F_qQ6Yssx2NdKM2mdtS0";
         cardTitle.text(title);
         cardSubtitle.text(subtitle);
         cardAuthor.text(authors);
-        // cardSynop.html(synop);
-        // cardBuy.text("Link to purchase: "+buyLink);
-        cardBuy.text("Link to google books: "+selfLink);
-        coverImg.attr("src", coverSm);
-        // cardSynop.html(synop);
-        cardBuy.text("Link to purchase: "+ buyLink);
+        cardSynop.html(synop);
+        cardBuy.text("Link to gbooks: "+ selfLink);
+        coverImg.attr("src", coverLg);
         coverImg.attr("width", 300);
         coverImg.attr("height", 400);
         resultsCard.attr("class", "card");

--- a/assets/script.js
+++ b/assets/script.js
@@ -24,11 +24,14 @@ var googleKey = "AIzaSyCgSuPSLRf6S38F_qQ6Yssx2NdKM2mdtS0";
         // var buyLink = bookGet.items[i].saleInfo.buyLink;
         var selfLink = bookGet.items[i].selfLink;
         
-        var authors = bookGet.items[i].volumeInfo.authors[0]; //in case of multiple authors this won't work
+        // var authors = bookGet.items[i].volumeInfo.authors[0]; //in case of multiple authors this won't work
         // var synop = bookGet.items[i].searchInfo.textSnippet;
-
+        
+        //Some objects return without a searchInfo array and will break the page, this checks to see if there is an index before calling it
         if (bookGet.items[i].searchInfo) {var synop = bookGet.items[i].searchInfo.textSnippet;}else{var synop ="Error"}
-
+        //Some pages do not provide author information, causing similar problem as above
+        //Currently author only displays the first author, in the case of multiple authors this ignores all but the first
+        if (bookGet.items[i].volumeInfo.authors) {var authors = bookGet.items[i].volumeInfo.authors[0];}else{var authors ="Error"}
 
         var resultsCard = $("<div>");
         var coverImg = $("<img>");


### PR DESCRIPTION
If either the synopsis or the author indices are empty or simply don't exist, the application will now not check for them and therefore not break when certain search criteria are entered (e.g. the jungle book). However there is still no solution to showing multiple authors, if we want that at all. If other similar bugs appear this solution should be easily repeatable  